### PR TITLE
Relax graphql version

### DIFF
--- a/graphql-schema-directive-constraint.gemspec
+++ b/graphql-schema-directive-constraint.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "graphql", "~> 1.0"
+  spec.add_dependency "graphql", "~> 2.0"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
issue: https://github.com/rrreeeyyy/graphql-schema-directive-constraint/issues/1

I didn't find any problems even if relax graphql version, so allow this gem to be used with graphql v2.x 🆙 